### PR TITLE
Hotfix: migrated from createBrowserRouter to createHashRouter

### DIFF
--- a/src/Routes/RouterConfig.jsx
+++ b/src/Routes/RouterConfig.jsx
@@ -1,11 +1,11 @@
-import { createBrowserRouter } from "react-router-dom";
+import { createHashRouter } from "react-router-dom";
 import Introduction from "../Pages/Introduction/Introduction";
 import Experiences from "../Pages/Experiences/Experiences";
 import Contacts from "../Pages/Contact/Contact";
 import NavbarLayout from "../Components/Navbar/NavbarLayout";
 import Skills from "../Pages/Skills/Skills";
 
-export const RouterConfig = createBrowserRouter(
+export const RouterConfig = createHashRouter(
   [
     {
       path: "/",
@@ -29,8 +29,5 @@ export const RouterConfig = createBrowserRouter(
         },
       ],
     },
-  ],
-  {
-    basename: "/portfolio",
-  }
+  ]
 );


### PR DESCRIPTION
#Updated navigation
- When the user refreshing a subpage (e.g. `https://simon-attila-fr.github.io/portfolio/#/experiences`), there is no error message and the selected page is rendered in the browser.
- URL's are chenged due to modified routing: `https://simon-attila-fr.github.io/portfolio/experiences` --> `https://simon-attila-fr.github.io/portfolio/#/experiences`